### PR TITLE
FEAT(main-page): 프로젝트 생성시 사용자 ux개선

### DIFF
--- a/src/apis/axiosInstance.js
+++ b/src/apis/axiosInstance.js
@@ -1,4 +1,6 @@
 import axios from "axios";
+import { use } from "react";
+import { useNavigate } from "react-router-dom";
 
 // const BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
@@ -27,6 +29,7 @@ axiosInstanceNoHeader.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
+    const navigate = useNavigate();
 
     if (
       error.response &&
@@ -39,7 +42,7 @@ axiosInstanceNoHeader.interceptors.response.use(
       if (originalRequest.url.includes("/token/refresh")) {
         localStorage.removeItem("accessToken");
         localStorage.removeItem("refreshToken");
-        window.location.href = "/login"; // 로그인 페이지로 리다이렉트
+        navigate("/login"); // 로그인 페이지로 리다이렉트
         return Promise.reject(error);
       }
 
@@ -52,7 +55,7 @@ axiosInstanceNoHeader.interceptors.response.use(
           console.log("refreshToken이 없습니다.");
           console.warn("refreshToken이 유효하지 않음:", refreshToken);
           localStorage.clear();
-          window.location.href = "/login";
+          navigate("/login");
           return Promise.reject("No refreshToken");
         }
         // refresh 요청 실행
@@ -75,7 +78,7 @@ axiosInstanceNoHeader.interceptors.response.use(
             // refresh 실패 시 토큰 제거
             localStorage.removeItem("accessToken");
             localStorage.removeItem("refreshToken");
-            window.location.href = "/login"; // 로그인 페이지로 리다이렉트
+            navigate("/login"); // 로그인 페이지로 리다이렉트
             throw err;
           })
           .finally(() => {

--- a/src/components/CreateProjectModal/CreateProjectModal.jsx
+++ b/src/components/CreateProjectModal/CreateProjectModal.jsx
@@ -3,6 +3,7 @@ import CloseOn from "../../assets/icons/Close/CloseOn";
 import Input from "../Input/Input";
 import Button from "../Button/Button";
 import { axiosInstanceNoHeader } from "../../apis/axiosInstance";
+import { useNavigate } from "react-router-dom";
 
 const CreateProjectModal = ({
   setNewProjectCreateModalOpen,
@@ -14,6 +15,7 @@ const CreateProjectModal = ({
   const [memberEmailList, setMemberEmailList] = useState([]);
   const [onSuccess, setOnSuccess] = useState(null);
   const [errMessage, setErrMessage] = useState("");
+  const navigate = useNavigate();
 
   const createProjectapi = async (projectName, description, memberEmail) => {
     const invitedEmails = memberEmailList.length > 0 ? memberEmailList : [];
@@ -25,8 +27,7 @@ const CreateProjectModal = ({
       });
       console.log("프로젝트 생성 성공~!\n", res);
       alert("프로젝트가 생성되었습니다.");
-      window.location.reload(); // 프로젝트 생성 후 페이지 새로고침
-
+      navigate(-1);
       return res;
     } catch (error) {
       console.log("프로젝트 생성 실패~!\n", error);

--- a/src/components/UserIdCard/UserIdCard.jsx
+++ b/src/components/UserIdCard/UserIdCard.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { axiosInstanceNoHeader } from "../../apis/axiosInstance";
 import PersonOn from "../../assets/icons/Person/PersonOn";
+import { useNavigate } from "react-router-dom";
 
 const UserIdCard = () => {
   const [userInfo, setUserInfo] = useState(null);
+  const navigate = useNavigate();
 
   const getUserIdInfo = async () => {
     try {
@@ -66,7 +68,7 @@ const UserIdCard = () => {
       <div
         className="text-center justify-center text-gray-400 text-xs font-bold font-['Palanquin'] leading-none cursor-pointer"
         onClick={() => {
-          window.location.href = "/mypage";
+          navigate("/mypage");
         }}
       >
         프로필 이동

--- a/src/pages/PasswordReset/PasswordReset.jsx
+++ b/src/pages/PasswordReset/PasswordReset.jsx
@@ -4,6 +4,7 @@ import Button from "../../components/Button/Button";
 import Input from "../../components/Input/Input";
 import CloseOn from "../../assets/icons/Close/CloseOn";
 import { axiosInstanceNoHeader } from "../../apis/axiosInstance";
+import { useNavigate } from "react-router-dom";
 
 const PasswordReset = () => {
   const [name, setName] = useState("");
@@ -16,6 +17,7 @@ const PasswordReset = () => {
   const [emailSuccess, setEmaiSuccess] = useState(null);
   const [passwordCheckSuccess, setpasswordCheckSuccess] = useState(null);
   const [userAuthCodeSuccess, setUserAuthCodeSuccess] = useState(null);
+  const navigate = useNavigate();
 
   const validateEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
@@ -119,7 +121,7 @@ const PasswordReset = () => {
         <div className="flex w-[700.92px] h-fit relative bg-white rounded-xl outline outline-1 outline-offset-[-1px] outline-gray-300 py-[105px] px-24">
           <div
             className="w-10 h-10 absolute rounded-2xl left-[610px] top-[51px] cursor-pointer"
-            onClick={() => (window.location.href = "/login")}
+            onClick={() => navigate("/login")}
           >
             <CloseOn />
           </div>

--- a/src/pages/Signup/Signup.jsx
+++ b/src/pages/Signup/Signup.jsx
@@ -5,6 +5,7 @@ import Input from "../../components/Input/Input";
 import Button from "../../components/Button/Button";
 import { axiosInstanceNoHeader } from "../../apis/axiosInstance";
 import Layout from "../../components/NavbarLayout/Layout";
+import { useNavigate } from "react-router-dom";
 
 const Signup = () => {
   const [name, setName] = useState("");
@@ -18,6 +19,7 @@ const Signup = () => {
   const [passwordSuccess, setpasswordSuccess] = useState(null);
   const [passwordCheckSuccess, setpasswordCheckSuccess] = useState(null);
   const [userAuthCodeSuccess, setUserAuthCodeSuccess] = useState(null);
+  const navigate = useNavigate();
 
   const validateEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
@@ -93,12 +95,12 @@ const Signup = () => {
       });
       console.log("회원가입 성공~!", res.data.result);
       alert("회원가입이 완료되었습니다");
-      window.location.href = "/login";
+      navigate("/login");
       return res;
     } catch (e) {
       console.log("회원가입요청 실패~ㅠ", e);
       alert("회원가입에 실패했습니다");
-      window.location.href = "/signup";
+      navigate("/signup");
     }
   };
 
@@ -118,7 +120,7 @@ const Signup = () => {
         <div className="flex w-[700.92px] h-fit relative bg-white rounded-xl outline outline-1 outline-offset-[-1px] outline-gray-300 py-[105px] px-24">
           <div
             className="w-10 h-10 absolute rounded-2xl left-[610px] top-[51px] cursor-pointer"
-            onClick={() => (window.location.href = "/login")}
+            onClick={() => navigate("/login")}
           >
             <CloseOn />
           </div>

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -4,8 +4,10 @@ import Button from "../../components/Button/Button";
 import { axiosInstanceNoHeader } from "../../apis/axiosInstance";
 import Layout from "../../components/NavbarLayout/Layout";
 import Input from "../../components/Input/Input";
+import { useNavigate } from "react-router-dom";
 
 const Login = () => {
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
@@ -17,12 +19,12 @@ const Login = () => {
       });
       console.log("로그인 성공~!\n", res);
       alert("로그인 되었습니다");
-      window.location.href = "/";
+      navigate("/");
       return res.headers;
     } catch (error) {
       console.log("로그인 실패~!\n", error);
       alert("로그인에 실패했습니다");
-      window.location.href = "/login";
+      navigate("/login");
       return error;
     }
   };
@@ -50,7 +52,7 @@ const Login = () => {
         <div className="flex w-[700.92px] h-[760px] relative bg-white rounded-xl outline outline-1 outline-offset-[-1px] outline-gray-300 overflow-hidden py-[105px] px-24">
           <div
             className="w-10 h-10 absolute rounded-2xl left-[610px] top-[51px] cursor-pointer"
-            onClick={() => (window.location.href = "/")}
+            onClick={() => navigate("/")}
           >
             <CloseOn />
           </div>


### PR DESCRIPTION
# 변경내용
* 프로젝트 생성 모달을 통해서 프로젝트 생성 완료시에 alert 버튼에서 완료를 누르면 페이지 새로고침
* 메인페이지에 새롭게 생성된 프로젝트 반영
---
* [회원가입, 비밀번호 재설정] 페이지 속 X 버튼 클릭시 로그인 페이지로 이동
* [로그인] 페이지 속 X 버튼 클릭시 메인페이지로 이동(리렌더링 돼서 결국 로그인 페이지로 이동함)
---
* window.location.href 사용 방식의 리렌더링을 모두 useNavigate방식으로 변경